### PR TITLE
Fix issue with Software Serial picking up wrong version 

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -15,5 +15,4 @@ framework = arduino
 lib_deps = 
 	sui77/rc-switch@^2.6.4
 	https://github.com/me-no-dev/ESPAsyncWebServer.git
-	plerup/EspSoftwareSerial@^7.0.0
-	jrowberg/I2Cdevlib-HMC5883L@^1.0.0
+    https://github.com/plerup/espsoftwareserial.git#7.0.0

--- a/src/Lib/SeaTalk.cpp
+++ b/src/Lib/SeaTalk.cpp
@@ -5,7 +5,7 @@
 /// @param signalManager Signal manager to send messages to other systems
 SeaTalk::SeaTalk(SignalManager *signalManager)
 {
-    _mySerial.begin(4800, SWSERIAL_8S1, RX_IN, TX_OUT, true, 95, 11);
+    _mySerial.begin(4800, SWSERIAL_8S1, RX_IN, TX_OUT, true, 95);
     _signalManager = signalManager;
 }
 


### PR DESCRIPTION
Software serial was picking up a new version than what I had cached which was broken . I've forced it to specificlaly use  the tag in github which has fixed the issue. Also fixed an issue with the buffer that i'd fixed in the next version .